### PR TITLE
Merge changes around XCLEN and issue #18

### DIFF
--- a/doc/tex/appx-notation.tex
+++ b/doc/tex/appx-notation.tex
@@ -223,10 +223,8 @@
       denotes the $i$-th,
            $32$-bit 
       entry in said register file.
-\item $\SPR{XCCR}$
-      and
-      $\SPR{XCSR}$
-      denote two \XCID-specific CSRs.
+\item $\SPR{XCSR}$
+      denotes the \XCID-specific Control and Status Register.
 
 \end{itemize}
 

--- a/doc/tex/bg-assumption.tex
+++ b/doc/tex/bg-assumption.tex
@@ -5,8 +5,15 @@
 
 \begin{itemize}
 
-\item Since \XCID is an explicitly an extension of RV32I, we retain the use
-      of \RVXLEN as a general placeholder but assume $\RVXLEN = 32$.
+\item We make no assumption about the value of $\RVXLEN$ for the base
+      architecture which \XCID extends.
+      \XCID is explicitly designed for use with microcontrollers, so
+      some design decisions will make more sense when considering
+      $\RVXLEN=32$.
+
+\item We use an analogous variable $\XCLEN$, defined in section
+     \ref{sec:spec:state:xcr}, to denote the width of additional \XCID
+     state.
 
 \item \XCID demands interaction with an RNG, the concrete instantiation of 
       which is unspecified: we assume the RNG design follows best-practice,

--- a/doc/tex/bg-compatibility.tex
+++ b/doc/tex/bg-compatibility.tex
@@ -13,7 +13,7 @@
       \begin{enumerate}
       \item Cryptographic Extensions Task Group,
       \item BitManip\footnote{
-            \url{https://github.com/cliffordwolf/xbitmanip}
+            \url{https://github.com/riscv/riscv-bitmanip}
             }                             Group,
             and
       \item P             Extension  Task Group (i.e., the embedded DSP-like ISE).
@@ -41,7 +41,7 @@
 
 \item \XCID is intended to be agnostic wrt. implementation for a given host 
       core.  As such, there is no conceptual reason preventing use within
-      RV64I or RV128I (vs. RV32I as specified).  
+      RV64I or RV128I (vs. RV32I as is notionally expected).  
 
 \end{itemize}
 

--- a/doc/tex/bg-feature.tex
+++ b/doc/tex/bg-feature.tex
@@ -32,11 +32,11 @@ a) one     required, baseline feature class
    plus
 b) several optional           feature classes
    which can be {\em selectively} supported to suit.
-To some extent, this mirrors the extensibility afforded by RV32I itself, 
+To some extent, this mirrors the extensibility afforded by RISC-V itself, 
 with similar motivation: doing so allows one to tailor the ISE (resp. ISA) 
-st. it suits a given context, which is important because some features are 
-applicable within a broad range of cryptographic workloads whereas others 
-are (more) specifically applicable (even niche).
+such that it suits a given context, which is important because some features
+are  applicable within a broad range of cryptographic workloads whereas
+others are (more) specifically applicable (even niche).
 
 The RISC-V naming convention~\cite[Section 22]{SCARV:RV:ISA:I:17} for ISEs
 uses a string of single-character identifiers to specify features realised
@@ -73,7 +73,7 @@ introduce
 \item $1$ additional register file
       (see \REFSEC{sec:spec:state:xcr}),
       and
-\item $2$ additional CSRs 
+\item $3$ additional CSRs
       (see \REFSEC{sec:spec:state:csr}),
 \end{itemize}
 
@@ -112,14 +112,18 @@ is included.
 All such instructions use a base address in $\GPR$, but {\em directly} load 
 and store to and from $\XCR$; this avoids having to first load content into 
 and then subsequently transfer it from $\GPR$.
-Although most are analogous to RV32I, there are some differences: note that
+Although most are analogous to the base RISC-V Integer ISA, there are some
+differences:
 
 \begin{itemize}
-\item variants that support different access granularity (e.g., half-word or
+\item Variants that support different access granularity (e.g., half-word or
       byte) are included; variants that support updating (or inserting, vs. 
-      overwriting) load semantics are also included,
-\item matching the context, access is considered to be unsigned throughout;
+      overwriting) load semantics are also included.
+\item Matching the context, access is considered to be unsigned throughout;
       there are no sign-extending variants, for example.
+\item XCrypto supports indexed load/store addressing, wherein the address
+      is the sum of two registers, in addition to the standard RISC-V
+      register-immediate addressing.
 \end{itemize}
 
 % =============================================================================
@@ -314,7 +318,7 @@ nor
 implicit (e.g., status flags for carry or borrow)
 state.
 Such an approach is particularly attractive when set within the context of 
-RV32I, because it avoids inclusion of status flags and so forces (somewhat 
+RISC-V, because it avoids inclusion of status flags and so forces (somewhat 
 high overhead) software-based carry and overflow management.
 
 % -----------------------------------------------------------------------------

--- a/doc/tex/spec-exception.tex
+++ b/doc/tex/spec-exception.tex
@@ -15,7 +15,7 @@ the following:
 \item Any attempt to execute a
         valid \XCID instruction
       from a privilege mode which does not have access to the ISE
-      (per fields in $\SPR{XCCR}$)
+      (per fields in $\SPR{XCSR}$)
       will cause an
       illegal instruction exception.
 \item Any attempt to execute a
@@ -24,7 +24,7 @@ the following:
       will cause an 
       illegal instruction exception.
 \item Any access to the 
-      $\SPR{XCSR}$ or $\SPR{XCCR}$
+      $\SPR{XCSR}$ or $\SPR{XCSR}$
       CSRs from a privilege mode other than machine mode
       will cause an 
       illegal instruction exception.

--- a/doc/tex/spec-instruction.tex
+++ b/doc/tex/spec-instruction.tex
@@ -9,17 +9,18 @@
 % -----------------------------------------------------------------------------
 
 \XCINSTR{xc.xcr2gpr}{rd, crs1}{
-  Move an $\XCR$ register to a $\GPR$ register.
+  Move an $\XCR$ register to a $\GPR$ register. The $\XCR$ register value is
+  zero padded upto $\RVXLEN$ bits.
 }{ 
-  $\GPR[*][{\VERB[RV]{rd}}] \ASN \XCR[*][{\VERB[RV]{crs1}}]$\;
+  $\GPR[*][{\VERB[RV]{rd}}] \ASN \EXT[\RVXLEN]{0}(\XCR[*][{\VERB[RV]{crs1}}])$\;
 }
 
 % -----------------------------------------------------------------------------
 
 \XCINSTR{xc.gpr2xcr}{crd, rs1}{
-  Move a $\GPR$ register to an $\XCR$ register.
+  Move the low $\XCLEN$ bits of a $\GPR$ register to an $\XCR$ register.
 }{
-  $\XCR[*][{\VERB[RV]{crd}}] \ASN \GPR[*][{\VERB[RV]{rs1}}]$\;
+  $\XCR[*][{\VERB[RV]{crd}}] \ASN \INDEX{\GPR[*][{\VERB[RV]{rs1}}]}{\XCLEN \RANGE 0}$\;
 }
 
 % -----------------------------------------------------------------------------

--- a/doc/tex/spec-state.tex
+++ b/doc/tex/spec-state.tex
@@ -35,8 +35,9 @@ x87 state, {\em must} be robustly mitigated.
 
 \XCID 
 demands one additional 
-$16$-element, $32$-bit register file;
-we refer to this as the $\XCR$ register file, distinguishing it from the
+$16$-element, $\XCLEN$-bit register file,
+where $\XCLEN = 32$.
+We refer to this as the $\XCR$ register file, distinguishing it from the
 general-purpose $\GPR$ register file specified by RV32I.
 Note that
 

--- a/doc/tex/spec-state.tex
+++ b/doc/tex/spec-state.tex
@@ -5,7 +5,7 @@ It is important to recognise the overhead, wrt. both
 time  (e.g., due to it needing to be context switched) 
 and 
 space (e.g., wrt. additional logic),
-relating to {\em any} state added to RV32I by \XCID.
+relating to {\em any} state added by \XCID.
 However, it also seems reasonable to align the trade-off(s) involved with 
 existing, common cases such as ISEs for floating-point arithmetic (namely
 the standard 
@@ -42,7 +42,7 @@ general-purpose $\GPR$ register file specified by RV32I.
 Note that
 
 \begin{itemize}
-\item RV32I specifies~\cite[Section 2.1]{SCARV:RV:ISA:I:17} that
+\item RISC-V specifies~\cite[Section 2.1]{SCARV:RV:ISA:I:17} that
       $
       \GPR[*][0] = 0 ,
       $
@@ -68,7 +68,7 @@ Note that
       Doing so aligns with \REFSEC{sec:bg:concept}, where the host core is 
       pitched as a control-path for the co-processor: address computation,
       control-flow orchestration, etc. fall under the remit of the former, 
-      since they can be supported by RV32I as is.
+      since they can be supported by the base RISC-V ISA as is.
 \item The $\XCR$ register file must have all values set to zero on a reset.
 \end{itemize}    
 
@@ -79,7 +79,7 @@ Note that
 
 \XCID 
 Requires three additional
-non-standard, CSRs~\cite[Section 2]{SCARV:RV:ISA:II:17}.
+non-standard CSRs~\cite[Section 2]{SCARV:RV:ISA:II:17}.
 In practice one physical register is required, with different shadow
 versions existing at different privilege levels.
 Table \ref{tab:csr} shows the address space layout of the additional


### PR DESCRIPTION
- Introduces the notion of `XCLEN` which is tied to 32, and represents the word width of the XCrypto registers.
- Redefines `xc.gpr2xcr` and `xc.xrr2gpr` in terms of `XCLEN`, to handle cases where `XCLEN != XLEN`.
- Adds some explanation that though XCrypto is *designed for* RV32, it can be used with RV64/128, even if some of the design choices then make less sense.